### PR TITLE
Fixed typing error in header README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-#sample-code
+# sample-code
 
 This repository contains sample applications which are used mostly by appium functional tests.


### PR DESCRIPTION
Inserted a space between '#' and text to make it a header.